### PR TITLE
タイムゾーン追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module Linebot2
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # 追加
+    config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#What
config/application.rbにてタイムゾーンの追加を実施。

#Why
時刻を日本時間にする。
文字を日本語設定する。